### PR TITLE
feat: add deployment URL annotations to preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -184,6 +184,10 @@ jobs:
           echo "api_key=$API_KEY" >> $GITHUB_OUTPUT
           echo "webhook_secret=$WEBHOOK_SECRET" >> $GITHUB_OUTPUT
 
+          # Output URLs for summary
+          echo "::notice::Backend deployed to ${{ steps.backend.outputs.api_url }}"
+          echo "::notice::Playground will be deployed to $PLAYGROUND_URL"
+
       - name: "Deploy playground"
         run: bun run infra:deploy --filter=playground
         env:


### PR DESCRIPTION
## Summary
Adds GitHub Actions annotations to the preview workflow to display deployment URLs directly in the workflow run summary, matching the behavior of the staging workflow.

## Changes
- Added `::notice::` annotations to preview workflow showing backend and playground URLs

## Benefits
- Deployment URLs are visible directly in the Actions run annotations
- Consistent with staging workflow behavior
- No need to dig through logs to find deployment URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)